### PR TITLE
Validations for git clone

### DIFF
--- a/privatevcs/validation/gitlab.go
+++ b/privatevcs/validation/gitlab.go
@@ -87,6 +87,14 @@ var gitlabPatterns = map[string]gitlabPattern{
 		Method: http.MethodPost,
 		Path:   regexp.MustCompile("^/api/v4/projects/(?P<project>[^/]+)/merge_requests/[0-9]+/notes$"),
 	},
+	"Git Clone - info/refs": {
+		Method: http.MethodGet,
+		Path:   regexp.MustCompile(`^/(?P<project>[^/]+\/[^/]+)\.git/info/refs$`),
+	},
+	"Git Clone - git-upload-pack": {
+		Method: http.MethodPost,
+		Path:   regexp.MustCompile(`^/(?P<project>[^/]+\/[^/]+)\.git/git-upload-pack$`),
+	},
 }
 
 func matchGitLabRequest(r *http.Request) (string, string, *string, error) {


### PR DESCRIPTION
## Description of the change

Validations for two additional URLs needed for git clone:
- GET /namespace/repo-name.git/info/refs?service=git-upload-pack
- POST /namespace/repo-name.git/git-upload-pack

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [x] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [x] Changes have been reviewed by at least one other engineer;
