### PR TITLE
Allow getting PR details from GitHub

### DIFF
--- a/privatevcs/validation/github_enterprise.go
+++ b/privatevcs/validation/github_enterprise.go
@@ -60,6 +60,10 @@ var githubEnterprisePatterns = map[string]githubEnterprisePattern{
 		Method: http.MethodGet,
 		Path:   regexp.MustCompile("^/(api/v3/)?repos/(?P<project>[^/]+/[^/]+)/pulls/[^/]+/files$"),
 	},
+	"Get Pull Request": {
+		Method: http.MethodGet,
+		Path:   regexp.MustCompile("^/(api/v3/)?repos/(?P<project>[^/]+/[^/]+)/pulls/[^/]+$"),
+	},
 	"Refresh Access Token": {
 		Method: http.MethodPost,
 		Path:   regexp.MustCompile("^/(api/v3/)?app/installations/[^/]+/access_tokens$"),

--- a/privatevcs/validation/github_enterprise_test.go
+++ b/privatevcs/validation/github_enterprise_test.go
@@ -171,6 +171,20 @@ func TestMatchingValidation(t *testing.T) {
 			method:  http.MethodGet,
 		},
 		{
+			path:    "/api/v3/repos/octocats/infra/pulls/123",
+			matches: true,
+			name:    "Get Pull Request",
+			project: nullable.String("octocats/infra"),
+			method:  http.MethodGet,
+		},
+		{
+			path:    "/repos/octocats/infra/pulls/123",
+			matches: true,
+			name:    "Get Pull Request",
+			project: nullable.String("octocats/infra"),
+			method:  http.MethodGet,
+		},
+		{
 			path:    "/api/v3/app/installations/29/access_tokens",
 			matches: true,
 			name:    "Refresh Access Token",


### PR DESCRIPTION
## Description of the change

We need to use the REST API to get PR details to calculate mergeability. Unfortunately the field we need is a preview feature in the GraphQL API, and isn't available in relatively recent GitHub Enterprise versions.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
