### PR TITLE
Allow Azure DevOps to "fail-open"

### DIFF
--- a/privatevcs/validation/azure_devops.go
+++ b/privatevcs/validation/azure_devops.go
@@ -92,5 +92,8 @@ func matchAzureDevOpsRequest(r *http.Request) (string, string, *string, error) {
 			return name, projectName, nil, nil
 		}
 	}
-	return "", "", nil, ErrNoMatch
+
+	// Temporarily just allow any resources - we'll restrict later once we're certain we have
+	// a stable set of endpoints in the validation rules
+	return "Unknown Request", "", nil, nil
 }

--- a/privatevcs/validation/azure_devops_test.go
+++ b/privatevcs/validation/azure_devops_test.go
@@ -103,11 +103,20 @@ func TestAzureDevOpsValidation(t *testing.T) {
 			name:    "List Resource Areas",
 			method:  http.MethodGet,
 		},
+		// Temporarily allow any request until we're sure we have the correct set of validation
+		// rules. Once we do, the following test case can be removed, and the failing test
+		// case can be uncommented.
 		{
-			path:    "/spacelift-development/backend/_apis/git/repositories/infra/pullRequests/1234/attachments/%2Fattachment.tar.gz?api-version=7.1-preview.1",
-			matches: false,
+			path:    "/spacelift-development/_apis/UnknownResource",
+			matches: true,
+			name:    "Unknown Request",
 			method:  http.MethodGet,
 		},
+		// {
+		// 	path:    "/spacelift-development/backend/_apis/git/repositories/infra/pullRequests/1234/attachments/%2Fattachment.tar.gz?api-version=7.1-preview.1",
+		// 	matches: false,
+		// 	method:  http.MethodGet,
+		// },
 	}
 
 	for i := range testCases {


### PR DESCRIPTION
## Description of the change

We may have to tweak the set of validation rules for Azure DevOps quite soon, so let's allow any request, but mark it as unknown until we're sure we have the correct set of rules.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [x] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [x] Changes have been reviewed by at least one other engineer;
