### PR TITLE
Support Azure DO in sub-paths

### DIFF
--- a/privatevcs/validation/azure_devops.go
+++ b/privatevcs/validation/azure_devops.go
@@ -14,55 +14,51 @@ type azureDevOpsPattern struct {
 var azureDevOpsPatterns = map[string]azureDevOpsPattern{
 	"Get Commit Diff": {
 		Method: http.MethodGet,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/diffs/commits$"),
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/diffs/commits$"),
 	},
 	"Create Pull Request Thread": {
 		Method: http.MethodPost,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/pullRequests/[^/]+/threads$"),
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/pullRequests/[^/]+/threads$"),
 	},
 	"List Branch Stats": {
 		Method: http.MethodGet,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/stats/branches$"),
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/stats/branches$"),
 	},
 	"Get Item": {
 		Method: http.MethodGet,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/items$"),
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/items$"),
 	},
 	"Create Commit Status": {
 		Method: http.MethodPost,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/commits/[^/]+/statuses$"),
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/commits/[^/]+/statuses$"),
 	},
 	"List Pull Requests": {
 		Method: http.MethodGet,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/pullRequests$"),
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/pullRequests$"),
 	},
 	"Get Pull Request": {
 		Method: http.MethodGet,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/pullRequests/[^/]+$"),
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/pullRequests/[^/]+$"),
 	},
 	"List Pull Request Labels": {
 		Method: http.MethodGet,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/pullRequests/[^/]+/labels$"),
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/pullRequests/[^/]+/labels$"),
 	},
-	"List Project Repositories": {
+	"List Repositories": {
 		Method: http.MethodGet,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories$"),
-	},
-	"List Organization Repositories": {
-		Method: http.MethodGet,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/_apis/git/repositories$"),
+		Path:   regexp.MustCompile("(/(?P<organization>[^/]+))?/(?P<project>[^/]+)/_apis/git/repositories$"),
 	},
 	"Get Commit": {
 		Method: http.MethodGet,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/commits/[^/]+$"),
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/commits/[^/]+$"),
 	},
 	"List Resource Locations": {
 		Method: http.MethodOptions,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/_apis$"),
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/_apis$"),
 	},
 	"List Resource Areas": {
 		Method: http.MethodGet,
-		Path:   regexp.MustCompile("^/(?P<organization>[^/]+)/_apis/ResourceAreas$"),
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/_apis/ResourceAreas$"),
 	},
 }
 


### PR DESCRIPTION
## Description of the change

Support Azure DevOps instances that are hosted on a child path rather than at the root of the domain. As part of doing this, I've had to merge the rules for listing organization and project repositories because it becomes impossible to distinguish between them with the information we have available.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [ ] Lint rules pass locally;
- [ ] All tests related to the changed code pass in development;

### Code review

- [ ] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
