### PR TITLE
Add Bitbucket mergeability requests

### DIFF
--- a/privatevcs/validation/bitbucket_datacenter.go
+++ b/privatevcs/validation/bitbucket_datacenter.go
@@ -28,7 +28,7 @@ var bitbucketDatacenterPatterns = map[string]bitbucketDatacenterPattern{
 		Method: http.MethodGet,
 		Path:   regexp.MustCompile(`^/rest/api/1.0/projects/(?P<projectKey>[^/]+)/repos/(?P<repositorySlug>[^/]+)/commits/(?P<commitSHA>[^/]+)$`),
 	},
-	"Get Diff": {
+	"Get PR Diff": {
 		Method: http.MethodGet,
 		Path:   regexp.MustCompile(`^/rest/api/1.0/projects/(?P<projectKey>[^/]+)/repos/(?P<repositorySlug>[^/]+)/pull-requests/[0-9]+/diff$`),
 	},
@@ -63,6 +63,14 @@ var bitbucketDatacenterPatterns = map[string]bitbucketDatacenterPattern{
 	"Make PR Comment": {
 		Method: http.MethodPost,
 		Path:   regexp.MustCompile("^/rest/api/1.0/projects/(?P<projectKey>[^/]+)/repos/(?P<repositorySlug>[^/]+)/pull-requests/[0-9]+/comments$"),
+	},
+	"Check PR Mergeability": {
+		Method: http.MethodGet,
+		Path:   regexp.MustCompile("^/rest/api/1.0/projects/(?P<projectKey>[^/]+)/repos/(?P<repositorySlug>[^/]+)/pull-requests/[0-9]+/merge$"),
+	},
+	"Compare Commits": {
+		Method: http.MethodGet,
+		Path:   regexp.MustCompile("^/rest/api/1.0/projects/(?P<projectKey>[^/]+)/repos/(?P<repositorySlug>[^/]+)/compare/commits$"),
 	},
 }
 


### PR DESCRIPTION
## Description of the change

Add new requests required to allow us to check if a given PR is mergeable. The "Compare Commits" request is used to check if the PR branch is diverged.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [x] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [x] Changes have been reviewed by at least one other engineer;
