### PR TITLE
Add GitLab list environments request

### DIFF
--- a/privatevcs/validation/gitlab.go
+++ b/privatevcs/validation/gitlab.go
@@ -56,6 +56,10 @@ var gitlabPatterns = map[string]gitlabPattern{
 		Method: http.MethodDelete,
 		Path:   regexp.MustCompile("^/api/v4/projects/(?P<project>[^/]+)/environments/[0-9]+$"),
 	},
+	"List Environments": {
+		Method: http.MethodGet,
+		Path:   regexp.MustCompile("^/api/v4/projects/(?P<project>[^/]+)/environments$"),
+	},
 	"Get Affected Files": {
 		Method: http.MethodGet,
 		Path:   regexp.MustCompile("^/api/v4/projects/(?P<project>[^/]+)/repository/compare$"),


### PR DESCRIPTION
## Description of the change

We make a request to list the existing environments when setting up a new stack. This allows us to reuse the existing environment if one already exists with the same name.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [x] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [x] Changes have been reviewed by at least one other engineer;
