### PR TITLE
Add 'get user details' request to github enterprise allowlist

### DIFF
--- a/privatevcs/validation/allowlist/github_enterprise.go
+++ b/privatevcs/validation/allowlist/github_enterprise.go
@@ -73,6 +73,10 @@ var githubEnterprisePatterns = map[string]githubEnterprisePattern{
 		Method: http.MethodGet,
 		Path:   regexp.MustCompile("^/(api/v3/)?app$"),
 	},
+	"Get user details": {
+		Method: http.MethodGet,
+		Path:   regexp.MustCompile("^/(api/v3/)?users/[^/]+$"),
+	},
 }
 
 func matchGitHubEnterpriseRequest(r *http.Request) (string, string, error) {

--- a/privatevcs/validation/allowlist/github_enterprise_test.go
+++ b/privatevcs/validation/allowlist/github_enterprise_test.go
@@ -220,6 +220,12 @@ func TestGitHubEnterpriseValidation(t *testing.T) {
 			name:    "Get app details",
 			method:  http.MethodGet,
 		},
+		{
+			path:    "/api/v3/users/spacelift",
+			matches: true,
+			name:    "Get user details",
+			method:  http.MethodGet,
+		},
 	}
 
 	for i := range testCases {


### PR DESCRIPTION
## Description of the change

This PR adds a request to get specific user's details to Github Enterprise allowlist.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
