### PR TITLE
Updated deprecated GH Action

### DIFF
--- a/.github/workflows/preprod-deployment.yml
+++ b/.github/workflows/preprod-deployment.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1.6.1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: eu-west-1
           role-to-assume: ${{ secrets.PREPROD_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1.6.1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: eu-west-1
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
## Description of the change

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [x] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [ ] Lint rules pass locally;
- [ ] All tests related to the changed code pass in development;

### Code review

- [ ] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
