### PR TITLE
Remove trailing slash in `targetBaseEndpoint` for vcs agent config

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -34,7 +35,7 @@ func New(poolConfig *privatevcs.AgentPoolConfig, targetBaseEndpoint, vendor stri
 	return &Agent{
 		metadata:           metadata,
 		poolConfig:         poolConfig,
-		targetBaseEndpoint: targetBaseEndpoint,
+		targetBaseEndpoint: strings.TrimSuffix(targetBaseEndpoint, "/"),
 		validator:          validator,
 		vendor:             validation.Vendor(vendor),
 	}


### PR DESCRIPTION
## Description of the change

Remove the trailing slash from the targetBaseEndpoint

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
