### PR TITLE
Add flag to disable HTTP response compression

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -33,6 +33,8 @@ type Agent struct {
 	metadata           map[string]string
 	validator          validation.Strategy
 	httpClient         RequestDoer
+
+	HTTPDisableResponseCompression bool
 }
 
 // New creates a new Agent.
@@ -136,6 +138,10 @@ func (a *Agent) handleRequest(ctx *spcontext.Context, id string, msg *privatevcs
 
 	for key, value := range msg.Headers {
 		req.Header.Set(key, value)
+	}
+
+	if a.HTTPDisableResponseCompression {
+		req.Header.Set("Accept-Encoding", "identity")
 	}
 
 	ctx, err = a.validator.Validate(ctx, a.vendor, req)

--- a/cmd/spacelift-vcs-agent/main.go
+++ b/cmd/spacelift-vcs-agent/main.go
@@ -112,6 +112,12 @@ var (
 		EnvVar: "SPACELIFT_VCS_AGENT_DEBUG_PRINT_ALL",
 		Usage:  "Whether to print all requests and responses to stdout.",
 	}
+
+	flagHTTPDisableResponseCompression = cli.BoolFlag{
+		Name:   "http-disable-response-compression",
+		EnvVar: "SPACELIFT_VCS_AGENT_HTTP_DISABLE_RESPONSE_COMPRESSION",
+		Usage:  "Whether to disable HTTP response compression.",
+	}
 )
 
 var app = &cli.App{
@@ -123,6 +129,7 @@ var app = &cli.App{
 		flagTargetBaseEndpoint,
 		flagVCSVendor,
 		flagDebugPrintAll,
+		flagHTTPDisableResponseCompression,
 	},
 	Action: func(cmdCtx *cli.Context) error {
 		availableVendorsMap := make(map[string]bool)
@@ -204,6 +211,7 @@ var app = &cli.App{
 			agentMetadata,
 			httpClient,
 		)
+		a.HTTPDisableResponseCompression = cmdCtx.Bool(flagHTTPDisableResponseCompression.Name)
 
 		parallelismSemaphore := make(chan struct{}, cmdCtx.Int(flagParallelism.Name))
 


### PR DESCRIPTION
## Description of the change

Adding a flag to disable HTTP response compression so it's easier to debug VCS related issues.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
