### PR TITLE
Add flag to remove HTTP header `Content-Length` from HTTP requests

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -35,6 +35,7 @@ type Agent struct {
 	httpClient         RequestDoer
 
 	HTTPDisableResponseCompression bool
+	HTTPRemoveHeaderContentLength  bool
 }
 
 // New creates a new Agent.
@@ -142,6 +143,10 @@ func (a *Agent) handleRequest(ctx *spcontext.Context, id string, msg *privatevcs
 
 	if a.HTTPDisableResponseCompression {
 		req.Header.Set("Accept-Encoding", "identity")
+	}
+
+	if a.HTTPRemoveHeaderContentLength {
+		req.Header.Del("Content-Length")
 	}
 
 	ctx, err = a.validator.Validate(ctx, a.vendor, req)

--- a/cmd/spacelift-vcs-agent/main.go
+++ b/cmd/spacelift-vcs-agent/main.go
@@ -118,6 +118,12 @@ var (
 		EnvVar: "SPACELIFT_VCS_AGENT_HTTP_DISABLE_RESPONSE_COMPRESSION",
 		Usage:  "Whether to disable HTTP response compression.",
 	}
+
+	flagHTTPRemoveContentLengthHeader = cli.BoolFlag{
+		Name:   "http-remove-content-length-header",
+		EnvVar: "SPACELIFT_VCS_AGENT_HTTP_REMOVE_CONTENT_LENGTH_HEADER",
+		Usage:  "Whether to remove Content-Length header from HTTP requests.",
+	}
 )
 
 var app = &cli.App{
@@ -130,6 +136,7 @@ var app = &cli.App{
 		flagVCSVendor,
 		flagDebugPrintAll,
 		flagHTTPDisableResponseCompression,
+		flagHTTPRemoveContentLengthHeader,
 	},
 	Action: func(cmdCtx *cli.Context) error {
 		availableVendorsMap := make(map[string]bool)
@@ -212,6 +219,7 @@ var app = &cli.App{
 			httpClient,
 		)
 		a.HTTPDisableResponseCompression = cmdCtx.Bool(flagHTTPDisableResponseCompression.Name)
+		a.HTTPRemoveHeaderContentLength = cmdCtx.Bool(flagHTTPRemoveContentLengthHeader.Name)
 
 		parallelismSemaphore := make(chan struct{}, cmdCtx.Int(flagParallelism.Name))
 

--- a/cmd/spacelift-vcs-agent/main.go
+++ b/cmd/spacelift-vcs-agent/main.go
@@ -122,7 +122,7 @@ var (
 	flagHTTPRemoveContentLengthHeader = cli.BoolFlag{
 		Name:   "http-remove-content-length-header",
 		EnvVar: "SPACELIFT_VCS_AGENT_HTTP_REMOVE_CONTENT_LENGTH_HEADER",
-		Usage:  "Whether to remove Content-Length header from HTTP requests.",
+		Usage:  "Whether to remove Content-Length header from HTTP requests (experimental, might be removed in a future release).",
 	}
 )
 


### PR DESCRIPTION
## Description of the change

Add a flag to remove the HTTP header `Content-Length` from HTTP requests.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
