### PR TITLE
Fix broken deployment workflows

### DIFF
--- a/.github/workflows/preprod-deployment.yml
+++ b/.github/workflows/preprod-deployment.yml
@@ -23,14 +23,6 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@master
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        if: ${{ github.ref == 'refs/heads/main' }}
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.PREPROD_AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
-
       - name: Mark source directory as safe. # This is some duct tape over the git version in the Go image complaining about this since one of the 1.19.x versions. Feel free to remove once it doesn't break the build anymore. See https://github.com/actions/runner/issues/2033 and https://github.com/actions/checkout/issues/760#issuecomment-1097797031
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
@@ -83,6 +75,41 @@ jobs:
         run: ./scripts/verify.sh $BIN_DIR $BASE_NAME
         env:
           SHORT_SHA: ${{ steps.vars.outputs.sha }}
+
+      - name: Upload the VCS Agent binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: vcs-agent-binary
+          path: build/
+          retention-days: 1
+
+  publish-preprod-agent-deployment:
+    name: Upload VCS agent binary and container image
+    needs: ["preprod-agent-deployment"]
+    runs-on: ubuntu-latest
+
+    env:
+      BIN_DIR: build
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+
+    steps:
+      - name: Download the VCS Agent binary
+        uses: actions/download-artifact@v3
+        with:
+          name: vcs-agent-binary
+          path: ./build
+          retention-days: 1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.PREPROD_AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 900
 
       - name: Upload the VCS Agent binary to downloads.spacelift.dev
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -107,7 +107,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           aws-region: eu-west-1
-          role-to-assume: ${{ secrets.PREPROD_AWS_ROLE_TO_ASSUME }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 900
 
       - name: Upload the VCS Agent binary to downloads.spacelift.io

--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -22,14 +22,6 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@master
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        if: ${{ github.ref == 'refs/heads/production' }}
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-duration-seconds: 900
-
       - name: Mark source directory as safe. # This is some duct tape over the git version in the Go image complaining about this since one of the 1.19.x versions. Feel free to remove once it doesn't break the build anymore. See https://github.com/actions/runner/issues/2033 and https://github.com/actions/checkout/issues/760#issuecomment-1097797031
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
@@ -82,6 +74,41 @@ jobs:
         run: ./scripts/verify.sh $BIN_DIR $BASE_NAME
         env:
           SHORT_SHA: ${{ steps.vars.outputs.sha }}
+
+      - name: Upload the VCS Agent binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: vcs-agent-binary
+          path: build/
+          retention-days: 1
+
+  publish-prod-agent-deployment:
+    name: Upload VCS agent binary and container image
+    needs: ["prod-agent-deployment"]
+    runs-on: ubuntu-latest
+
+    env:
+      BIN_DIR: build
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+
+    steps:
+      - name: Download the VCS Agent binary
+        uses: actions/download-artifact@v3
+        with:
+          name: vcs-agent-binary
+          path: ./build
+          retention-days: 1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.PREPROD_AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 900
 
       - name: Upload the VCS Agent binary to downloads.spacelift.io
         if: ${{ github.ref == 'refs/heads/production' }}


### PR DESCRIPTION
## Description of the change

Separated deployment workflows to have two different jobs one for building the binary and one for publishing both the binary and the container image

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [X] Lint rules pass locally;
- [X] All tests related to the changed code pass in development;

### Code review

- [ ] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
