### PR TITLE
Fix Goreleaser warning (fetch depth)

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
 
       - name: Publish binary & Docker image
         uses: ./.github/workflows/publish


### PR DESCRIPTION
## Description of the change

I hope this is my last fix, but I can't promise anything. Sorry. :D

<img width="828" alt="image" src="https://github.com/spacelift-io/vcs-agent/assets/19969687/45abafda-3d56-49ae-bf7e-f1bf687103c2">


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [ ] Lint rules pass locally;
- [ ] All tests related to the changed code pass in development;

### Code review

- [ ] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
