### PR TITLE
chore: upgrade bugsnag client lib to v2

### DIFF
--- a/cmd/spacelift-vcs-agent/main.go
+++ b/cmd/spacelift-vcs-agent/main.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/bugsnag/bugsnag-go"
+	"github.com/bugsnag/bugsnag-go/v2"
 	"github.com/go-kit/log"
 	"github.com/spacelift-io/spcontext"
 	"github.com/urfave/cli"

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/kr/text v0.2.0
 	github.com/onsi/gomega v1.33.1
 	github.com/pkg/errors v0.9.1
-	github.com/spacelift-io/spcontext v0.0.3
+	github.com/spacelift-io/spcontext v0.0.4
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli v1.22.15
 	google.golang.org/grpc v1.65.0
@@ -18,7 +18,6 @@ require (
 )
 
 require (
-	github.com/bugsnag/bugsnag-go v2.4.0+incompatible // indirect
 	github.com/bugsnag/panicwrap v1.3.4 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/spacelift-io/vcs-agent
 go 1.22
 
 require (
-	github.com/bugsnag/bugsnag-go v2.4.0+incompatible
+	github.com/bugsnag/bugsnag-go/v2 v2.5.0
 	github.com/franela/goblin v0.0.0-20211003143422-0a4f594942bf
 	github.com/go-kit/log v0.2.1
 	github.com/kr/text v0.2.0
@@ -18,6 +18,7 @@ require (
 )
 
 require (
+	github.com/bugsnag/bugsnag-go v2.4.0+incompatible // indirect
 	github.com/bugsnag/panicwrap v1.3.4 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pgdoow=
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
-github.com/bugsnag/bugsnag-go v2.4.0+incompatible h1:WuUzek5dHy2AHG8lArEwAx6yv/eNKl4ydOCi9vCuHzU=
-github.com/bugsnag/bugsnag-go v2.4.0+incompatible/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/bugsnag-go/v2 v2.5.0 h1:kOf+3Rlv7KRrgaYj26GKvSntVeJrB2xQXvqfK0efojA=
 github.com/bugsnag/bugsnag-go/v2 v2.5.0/go.mod h1:S9njhE7l6XCiKycOZ2zp0x1zoEE5nL3HjROCSsKc/3c=
 github.com/bugsnag/panicwrap v1.3.4 h1:A6sXFtDGsgU/4BLf5JT0o5uYg3EeKgGx3Sfs+/uk3pU=
@@ -72,8 +70,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/spacelift-io/spcontext v0.0.3 h1:2o3AKdgUBuMwyLJ3G0VFE75DvIZh85giMajf6ejzk2g=
-github.com/spacelift-io/spcontext v0.0.3/go.mod h1:w8Hc/22SXWoGALMZwbpkz7yp9O5FsQtgceInuDPc3QQ=
+github.com/spacelift-io/spcontext v0.0.4 h1:MwwvpteOQ7VD1siOBj4YSEkY+5Hu81K8sPWeXYMp6Q0=
+github.com/spacelift-io/spcontext v0.0.4/go.mod h1:je8Hq4mFeTVUY8VPEXrb5TNEOl6dORx03rpRgJbpVQk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pg
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
 github.com/bugsnag/bugsnag-go v2.4.0+incompatible h1:WuUzek5dHy2AHG8lArEwAx6yv/eNKl4ydOCi9vCuHzU=
 github.com/bugsnag/bugsnag-go v2.4.0+incompatible/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
+github.com/bugsnag/bugsnag-go/v2 v2.5.0 h1:kOf+3Rlv7KRrgaYj26GKvSntVeJrB2xQXvqfK0efojA=
+github.com/bugsnag/bugsnag-go/v2 v2.5.0/go.mod h1:S9njhE7l6XCiKycOZ2zp0x1zoEE5nL3HjROCSsKc/3c=
 github.com/bugsnag/panicwrap v1.3.4 h1:A6sXFtDGsgU/4BLf5JT0o5uYg3EeKgGx3Sfs+/uk3pU=
 github.com/bugsnag/panicwrap v1.3.4/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
## Description of the change

We are currently using the v1 of the bugsnag library which hasn't received releases in 2 years. We're missing bugfixes and features. For example, v1 doesn't support unwrapping.

spcontext was updated here: https://github.com/spacelift-io/spcontext/pull/20

See: https://app.clickup.com/t/8695ccuv1 for more details

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [ ] Lint rules pass locally;
- [ ] All tests related to the changed code pass in development;

### Code review

- [ ] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
