### PR TITLE
adds 'update PR comment' routes to allowlist

### DIFF
--- a/privatevcs/validation/allowlist/azure_devops.go
+++ b/privatevcs/validation/allowlist/azure_devops.go
@@ -20,6 +20,14 @@ var azureDevOpsPatterns = map[string]azureDevOpsPattern{
 		Method: http.MethodPost,
 		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/pullRequests/[^/]+/threads$"),
 	},
+	"Get Pull Request Thread": {
+		Method: http.MethodGet,
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/pullRequests/[^/]+/threads/[0-9]+$"),
+	},
+	"Update Pull Request Comment": {
+		Method: http.MethodPatch,
+		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/pullRequests/[^/]+/threads/[0-9]+/comments/[0-9]+$"),
+	},
 	"List Branch Stats": {
 		Method: http.MethodGet,
 		Path:   regexp.MustCompile("/(?P<organization>[^/]+)/(?P<project>[^/]+)/_apis/git/repositories/(?P<repositoryId>[^/]+)/stats/branches$"),

--- a/privatevcs/validation/allowlist/azure_devops_test.go
+++ b/privatevcs/validation/allowlist/azure_devops_test.go
@@ -125,6 +125,18 @@ func TestAzureDevOpsValidation(t *testing.T) {
 		// 	matches: false,
 		// 	method:  http.MethodGet,
 		// },
+		{
+			path:    "/spacelift-development/backend/_apis/git/repositories/spacelift-dev-stack/pullRequests/123/threads/1",
+			matches: true,
+			name:    "Get Pull Request Thread",
+			method:  http.MethodGet,
+		},
+		{
+			path:    "/spacelift-development/backend/_apis/git/repositories/spacelift-dev-stack/pullRequests/123/threads/1/comments/1",
+			matches: true,
+			name:    "Update Pull Request Comment",
+			method:  http.MethodPatch,
+		},
 	}
 
 	executeTestCase := func(testCase azureDevOpsTestCase) {

--- a/privatevcs/validation/allowlist/bitbucket_datacenter.go
+++ b/privatevcs/validation/allowlist/bitbucket_datacenter.go
@@ -72,6 +72,14 @@ var bitbucketDatacenterPatterns = map[string]bitbucketDatacenterPattern{
 		Method: http.MethodGet,
 		Path:   regexp.MustCompile("^/rest/api/1.0/projects/(?P<projectKey>[^/]+)/repos/(?P<repositorySlug>[^/]+)/compare/commits$"),
 	},
+	"Get a single Pull Request Comment": {
+		Method: http.MethodGet,
+		Path:   regexp.MustCompile("^/rest/api/1.0/projects/(?P<projectKey>[^/]+)/repos/(?P<repositorySlug>[^/]+)/pull-requests/[0-9]+/comments/[0-9]+$"),
+	},
+	"Update a Pull Request Comment": {
+		Method: http.MethodPut,
+		Path:   regexp.MustCompile("^/rest/api/1.0/projects/(?P<projectKey>[^/]+)/repos/(?P<repositorySlug>[^/]+)/pull-requests/[0-9]+/comments/[0-9]+$"),
+	},
 }
 
 func matchBitbucketDatacenterRequest(r *http.Request) (string, string, error) {

--- a/privatevcs/validation/allowlist/gitlab.go
+++ b/privatevcs/validation/allowlist/gitlab.go
@@ -100,6 +100,10 @@ var gitlabPatterns = map[string]gitlabPattern{
 		Method: http.MethodPost,
 		Path:   regexp.MustCompile("^/api/v4/projects/(?P<project>[^/]+)/merge_requests/[0-9]+/notes$"),
 	},
+	"Update Merge Request Note": {
+		Method: http.MethodPut,
+		Path:   regexp.MustCompile("^/api/v4/projects/(?P<project>[^/]+)/merge_requests/[0-9]+/notes/[0-9]+$"),
+	},
 	"Git Clone - info/refs": {
 		Method: http.MethodGet,
 		Path:   regexp.MustCompile(`^/(?P<project>[^/]+\/[^/]+)\.git/info/refs$`),

--- a/privatevcs/validation/allowlist/match_request.go
+++ b/privatevcs/validation/allowlist/match_request.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ErrNoMatch is returned when the request didn't match any planned API usage.
-var ErrNoMatch = fmt.Errorf("no match for request")
+var ErrNoMatch = fmt.Errorf("vcs-agent: no match for request")
 
 var vendorMatchers = map[validation.Vendor]func(r *http.Request) (name string, project string, err error){
 	validation.AzureDevOps:         matchAzureDevOpsRequest,


### PR DESCRIPTION
## Description of the change

As part of CU-8694k6wnq (Allow notification policy to update PR comment in-place) new endpoints were added for the VCSs, in order to update the PR comments.

This change was meant to add support for Bitbucket Data Center, but because it was not known at that time that the new VCS routes must be added to the allowlist, it also add the missing routes for the Azure DevOps and Gitlab. Github enterprise doesn't need to be updated as it uses GraphQL and the main route is already added to the allowlist.

The allowlist NoMatch error message was changed in order to be clearer and avoid being confused with the gock package errors when testing (when trying to mock a HTTP request in tests, if the request URL was not in the allowlist, the test use to failed with "no match for request" which was easily confused to "the request was not properly mocked")

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [x] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [x] Changes have been reviewed by at least one other engineer;
