### PR TITLE
ci: add Trivy fallback DB repositories

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,20 +28,24 @@ jobs:
           repository_url: "ghcr.io/spacelift-io/vcs-agent"
 
       - name: Run Trivy vulnerability scanner (amd64)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.27.0
         with:
           image-ref: "ghcr.io/spacelift-io/vcs-agent:${{ fromJson(steps.goreleaser.outputs.metadata).version }}-amd64"
           format: "sarif"
           output: "trivy-results-amd64.sarif"
           severity: "CRITICAL,HIGH"
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
 
       - name: Run Trivy vulnerability scanner (arm64)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.27.0
         with:
           image-ref: "ghcr.io/spacelift-io/vcs-agent:${{ fromJson(steps.goreleaser.outputs.metadata).version }}-arm64"
           format: "sarif"
           output: "trivy-results-arm64.sarif"
           severity: "CRITICAL,HIGH"
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
 
       - name: Upload Trivy scan results to GitHub Security tab (amd64)
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
## Description of the change

Just adding these now to try to avoid people hitting the Trivy rate limiting issues later.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [x] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
