### PR TITLE
chore: fixing a couple of linter errors

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -108,7 +108,7 @@ func (a *Agent) Run(ctx *spcontext.Context) (outErr error) {
 		case *privatevcs.Request_HttpRequest:
 			responseMsg = a.handleRequest(ctx, msg.Id, req.HttpRequest)
 		case *privatevcs.Request_PingRequest:
-			responseMsg = a.handlePing(ctx, msg.Id, req.PingRequest)
+			responseMsg = a.handlePing(msg.Id)
 		}
 
 		if err := stream.Send(responseMsg); err != nil {
@@ -212,7 +212,7 @@ func (a *Agent) handleRequest(ctx *spcontext.Context, id string, msg *privatevcs
 	}
 }
 
-func (a *Agent) handlePing(ctx *spcontext.Context, id string, msg *privatevcs.PingRequest) *privatevcs.Response {
+func (a *Agent) handlePing(id string) *privatevcs.Response {
 	return &privatevcs.Response{
 		Id: id,
 		Content: &privatevcs.Response_PingResponse{

--- a/privatevcs/validation/codeload_test.go
+++ b/privatevcs/validation/codeload_test.go
@@ -22,7 +22,7 @@ func TestRewriteGitHubTarballRequest(t *testing.T) {
 			t.Fatalf("failed to create request: %v", err)
 		}
 
-		ctx = validation.RewriteGitHubTarballRequest(ctx, vendor, req)
+		validation.RewriteGitHubTarballRequest(ctx, vendor, req)
 
 		assert.Equal(t, "gitlab.com", req.URL.Host)
 	})
@@ -38,7 +38,7 @@ func TestRewriteGitHubTarballRequest(t *testing.T) {
 				t.Fatalf("failed to create request: %v", err)
 			}
 
-			ctx = validation.RewriteGitHubTarballRequest(ctx, vendor, req)
+			validation.RewriteGitHubTarballRequest(ctx, vendor, req)
 
 			assert.Equal(t, "github.corp.com", req.URL.Host)
 		})
@@ -54,7 +54,7 @@ func TestRewriteGitHubTarballRequest(t *testing.T) {
 					t.Fatalf("failed to create request: %v", err)
 				}
 
-				ctx = validation.RewriteGitHubTarballRequest(ctx, vendor, req)
+				validation.RewriteGitHubTarballRequest(ctx, vendor, req)
 
 				assert.Equal(t, "github.corp.com", req.URL.Host)
 			})
@@ -69,7 +69,7 @@ func TestRewriteGitHubTarballRequest(t *testing.T) {
 					t.Fatalf("failed to create request: %v", err)
 				}
 
-				ctx = validation.RewriteGitHubTarballRequest(ctx, vendor, req)
+				validation.RewriteGitHubTarballRequest(ctx, vendor, req)
 
 				assert.Equal(t, "codeload.github.corp.com", req.URL.Host)
 			})


### PR DESCRIPTION
## Description of the change

I noticed we had some failing lint rules when opening a PR. This should fix them.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [x] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
