### PR TITLE
feat: dual-write VCS Agent binaries to Cloudflare R2

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,3 +33,10 @@ jobs:
           gpg_base64_key: ${{ secrets.GPG_KEY_BASE64 }}
           gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          r2_bucket: ${{ startsWith(github.ref, 'refs/tags/v') && vars.R2_BUCKET || vars.PREPROD_R2_BUCKET }}
+          r2_endpoint: ${{ startsWith(github.ref, 'refs/tags/v') && vars.R2_ENDPOINT_URL || vars.PREPROD_R2_ENDPOINT_URL }}
+          r2_access_key_id: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.R2_ACCESS_KEY_ID || secrets.PREPROD_R2_ACCESS_KEY_ID }}
+          r2_secret_access_key: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.R2_SECRET_ACCESS_KEY || secrets.PREPROD_R2_SECRET_ACCESS_KEY }}
+          cloudflare_zone_id: ${{ startsWith(github.ref, 'refs/tags/v') && vars.EU_DOWNLOADS_CLOUDFLARE_ZONE_ID || vars.PREPROD_DOWNLOADS_CLOUDFLARE_ZONE_ID }}
+          cloudflare_purge_token: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.EU_CLOUDFLARE_CACHE_PURGE_TOKEN || secrets.PREPROD_CLOUDFLARE_CACHE_PURGE_TOKEN }}
+          cloudflare_purge_prefix: ${{ startsWith(github.ref, 'refs/tags/v') && vars.EU_DOWNLOADS_CLOUDFLARE_PURGE_PREFIX || vars.PREPROD_DOWNLOADS_CLOUDFLARE_PURGE_PREFIX }}

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -150,7 +150,7 @@ runs:
 
     - name: Purge Cloudflare cache for spacelift-vcs-agent
       if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
-      uses: spacelift-io/shared-actions/actions/purge-cloudflare-cache@main
+      uses: spacelift-io/public-shared-actions/actions/purge-cloudflare-cache@main
       with:
         zone_id: ${{ inputs.cloudflare_zone_id }}
         api_token: ${{ inputs.cloudflare_purge_token }}

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -150,28 +150,8 @@ runs:
 
     - name: Purge Cloudflare cache for spacelift-vcs-agent
       if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
-      shell: bash
-      env:
-        ZONE_ID: ${{ inputs.cloudflare_zone_id }}
-        PREFIX: ${{ inputs.cloudflare_purge_prefix }}
-        CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare_purge_token }}
-      run: |
-        set -euo pipefail
-        BODY=$(jq -nc --arg p "$PREFIX" '{prefixes:[$p]}')
-
-        if ! response=$(curl --fail-with-body --silent --show-error \
-            --retry 3 --retry-connrefused --retry-max-time 60 --max-time 15 \
-            -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/purge_cache" \
-            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-            -H "Content-Type: application/json" \
-            --data "$BODY"); then
-          printf 'ERROR: Cloudflare purge request failed: %s\n' "$response" >&2
-          exit 1
-        fi
-
-        if ! jq -e '.success == true' <<<"$response" >/dev/null 2>&1; then
-          printf 'ERROR: Cloudflare purge was not successful: %s\n' "$response" >&2
-          exit 1
-        fi
-
-        echo "Cloudflare cache purged"
+      uses: spacelift-io/shared-actions/actions/purge-cloudflare-cache@main
+      with:
+        zone_id: ${{ inputs.cloudflare_zone_id }}
+        api_token: ${{ inputs.cloudflare_purge_token }}
+        purge_prefixes: ${{ inputs.cloudflare_purge_prefix }}

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -29,6 +29,27 @@ inputs:
   github_token:
     description: The GitHub token. Used to authenticate with GitHub.
     required: true
+  r2_bucket:
+    description: The Cloudflare R2 bucket name. Used to upload the binaries.
+    required: true
+  r2_endpoint:
+    description: The Cloudflare R2 S3-compatible endpoint URL.
+    required: true
+  r2_access_key_id:
+    description: The Cloudflare R2 access key ID.
+    required: true
+  r2_secret_access_key:
+    description: The Cloudflare R2 secret access key.
+    required: true
+  cloudflare_zone_id:
+    description: The Cloudflare zone ID for downloads.<domain>. Used for cache purge.
+    required: true
+  cloudflare_purge_token:
+    description: The Cloudflare API token with Zone:Cache Purge:Purge permission.
+    required: true
+  cloudflare_purge_prefix:
+    description: URL prefix (without scheme) to purge from the Cloudflare edge cache, e.g. downloads.spacelift.io/spacelift-vcs-agent.
+    required: true
 
 runs:
   using: composite
@@ -105,7 +126,20 @@ runs:
       if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       shell: bash
       run: aws s3 sync build/ s3://${{ inputs.aws_bucket }}
-    
+
+    - name: Upload the VCS Agent binaries to Cloudflare R2
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.r2_access_key_id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.r2_secret_access_key }}
+        AWS_SESSION_TOKEN: ""
+        AWS_REGION: auto
+        AWS_EC2_METADATA_DISABLED: "true"
+        BUCKET: ${{ inputs.r2_bucket }}
+        ENDPOINT: ${{ inputs.r2_endpoint }}
+      run: aws s3 sync build/ "s3://$BUCKET" --endpoint-url "$ENDPOINT"
+
     - name: Invalidate downloads.spacelift.[dev|io] cache
       if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       shell: bash
@@ -113,3 +147,31 @@ runs:
         aws cloudfront create-invalidation
         --distribution-id ${{ inputs.cloudfront_distribution }}
         --paths "/*"
+
+    - name: Purge Cloudflare cache for spacelift-vcs-agent
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+      shell: bash
+      env:
+        ZONE_ID: ${{ inputs.cloudflare_zone_id }}
+        PREFIX: ${{ inputs.cloudflare_purge_prefix }}
+        CLOUDFLARE_API_TOKEN: ${{ inputs.cloudflare_purge_token }}
+      run: |
+        set -euo pipefail
+        BODY=$(jq -nc --arg p "$PREFIX" '{prefixes:[$p]}')
+
+        if ! response=$(curl --fail-with-body --silent --show-error \
+            --retry 3 --retry-connrefused --retry-max-time 60 --max-time 15 \
+            -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/purge_cache" \
+            -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data "$BODY"); then
+          printf 'ERROR: Cloudflare purge request failed: %s\n' "$response" >&2
+          exit 1
+        fi
+
+        if ! jq -e '.success == true' <<<"$response" >/dev/null 2>&1; then
+          printf 'ERROR: Cloudflare purge was not successful: %s\n' "$response" >&2
+          exit 1
+        fi
+
+        echo "Cloudflare cache purged"


### PR DESCRIPTION

Changes:
Dual-write VCS Agent binaries to Cloudflare R2

Example run:  [publish](https://github.com/spacelift-io/vcs-agent/actions/runs/28022310381/job/82941392512)

> Note:
Environment variables and secrets added on repository.

```bash
<prefix>_R2_BUCKET=
<prefix>_R2_ENDPOINT_URL=https://<accountId>.eu.r2.cloudflarestorage.com
<prefix>_R2_ACCESS_KEY_ID=
<prefix>_R2_SECRET_ACCESS_KEY=
<prefix>_DOWNLOADS_CLOUDFLARE_ZONE_ID=
<prefix>_DOWNLOADS_CLOUDFLARE_PURGE_PREFIX=
<prefix>_CLOUDFLARE_CACHE_PURGE_TOKEN=
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected);
- [ ] Other (miscellaneous, GitHub workflow changes, changes to the PR template);

## Checklists

### Development

- [x] Lint rules pass locally;
- [x] All tests related to the changed code pass in development;

### Code review

- [x] This pull request has a descriptive title and sufficient context for a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer a draft;

### Deployment

- [ ] Selected merge strategy is [squash merge](https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits);
- [ ] Changes have been reviewed by at least one other engineer;
